### PR TITLE
홈 화면 > 에디터/뷰 노출 변경

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -51,13 +51,20 @@
 
 .code {
   overflow: hidden;
+  display: none;
   border: 1px solid #424242;
   border-radius: 0 4px 4px 4px;
+
+  &.activate {
+    display: block;
+  }
 }
 
-.view {
-  width: 380px;
-  height: 380px;
+.result {
+  .code {
+    width: 380px;
+    height: 380px;
+  }
 }
 
 .box {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,26 +59,18 @@ export default function Index() {
             css
           </button>
         </div>
-        <div className={styles.code}>
-          {activeHtmlStateTab ? (
-            <CodeMirror
-              value={htmlDefaultState}
-              theme={okaidia}
-              width="380px"
-              height="380px"
-              extensions={[html({ autoCloseTags: true })]}
-              onChange={handleHtmlState}
-            />
-          ) : (
-            <CodeMirror
-              value={cssDefaultState}
-              theme={okaidia}
-              width="380px"
-              height="380px"
-              extensions={[css()]}
-              onChange={handleCssState}
-            />
-          )}
+        <div className={classnames(styles.code, { [styles.activate]: activeHtmlStateTab })}>
+          <CodeMirror
+            value={htmlDefaultState}
+            theme={okaidia}
+            width="380px"
+            height="380px"
+            extensions={[html({ autoCloseTags: true })]}
+            onChange={handleHtmlState}
+          />
+        </div>
+        <div className={classnames(styles.code, { [styles.activate]: !activeHtmlStateTab })}>
+          <CodeMirror value={cssDefaultState} theme={okaidia} width="380px" height="380px" extensions={[css()]} onChange={handleCssState} />
         </div>
         <div className={styles.tab}>
           <button
@@ -100,20 +92,14 @@ export default function Index() {
             answer
           </button>
         </div>
-        <div className={styles.code}>
-          <div className={styles.view}>
-            {activeUserViewTab ? (
-              /* html + css 코드 결과 영역입니다. 
-                이곳에 Shadow Dom 사용허여 구현하시면 됩니다.
-              */
-              // eslint-disable-next-line react/jsx-no-useless-fragment
-              <></>
-            ) : (
-              /* 정답 공간 뷰 영역입니다 */
-              // eslint-disable-next-line react/jsx-no-useless-fragment
-              <></>
-            )}
+        <div className={styles.result}>
+          <div className={classnames(styles.code, { [styles.activate]: activeUserViewTab })}>
+            {/*
+              html + css 코드 결과 영역입니다. 
+              이곳에 Shadow Dom 사용허여 구현하시면 됩니다.
+            */}
           </div>
+          <div className={classnames(styles.code, { [styles.activate]: !activeUserViewTab })}>{/* 정답 공간 뷰 영역입니다 */}</div>
         </div>
         <div className={styles.box}>
           <Link href="./" className={classnames(styles.link_start, 'contrast')}>


### PR DESCRIPTION
## 작업 내역
- https://github.com/Front-line-dev/markup-educator/pull/19#discussion_r1168708872 해당 코멘트에서 남겨주신 부분을 반영했습니다.
- `<CodeMirror>` 노출 부분만 바꾸려고 생각했는데요, 유저 및 정답 뷰 노출 부분도 현재 마크업상 비슷해서 동일하게 적용했습니다.