### PR TITLE
사용자 로컬 스토리지에서 코드 에디터 내용 불러오기

### DIFF
--- a/src/model/db.ts
+++ b/src/model/db.ts
@@ -1,0 +1,20 @@
+import Dexie, { Table } from 'dexie';
+
+export interface Markup {
+  id: string;
+  htmlState: string;
+  cssState: string;
+}
+
+export class MySubClassedDexie extends Dexie {
+  markups!: Table<Markup>;
+
+  constructor() {
+    super('CamuDatabase');
+    this.version(1).stores({
+      markups: 'id',
+    });
+  }
+}
+
+export const db = new MySubClassedDexie();

--- a/src/package.json
+++ b/src/package.json
@@ -23,6 +23,8 @@
     "@uiw/codemirror-theme-okaidia": "^4.19.11",
     "@uiw/react-codemirror": "^4.19.11",
     "classnames": "^2.3.2",
+    "dexie": "^3.2.3",
+    "dexie-react-hooks": "^1.1.3",
     "eslint": "^8.36.0",
     "html-to-image": "^1.11.11",
     "next": "^13.2.4",

--- a/src/pages/test1.tsx
+++ b/src/pages/test1.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@model/db';
-import CodeMirror from '@uiw/react-codemirror';
-import { okaidia } from '@uiw/codemirror-theme-okaidia';
-import { html } from '@codemirror/lang-html';
-import { css } from '@codemirror/lang-css';
+import Editor from '@component/Editor';
 
 const router = 'test1';
 
@@ -46,8 +43,8 @@ export default function Test1() {
 
   return (
     <div>
-      <CodeMirror value={htmlState} theme={okaidia} width="380px" height="380px" extensions={[html({ autoCloseTags: true })]} onChange={updateState} />
-      <CodeMirror value={cssState} theme={okaidia} width="380px" height="380px" extensions={[css()]} onChange={updateState} />
+      <Editor lang="html" initialString={htmlState} setState={updateState} />
+      <Editor lang="html" initialString={htmlState} setState={updateState} />
     </div>
   );
 }

--- a/src/pages/test1.tsx
+++ b/src/pages/test1.tsx
@@ -34,12 +34,11 @@ export default function Test1() {
       console.error(error);
     }
   };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (dataBaseItem) {
-      setHtmlState(dataBaseItem?.htmlState);
-      setCssState(dataBaseItem?.cssState);
-    }
-  }, [dataBaseItem]);
+    setHtmlState(dataBaseItem?.htmlState);
+    setCssState(dataBaseItem?.cssState);
+  });
 
   return (
     <div>

--- a/src/pages/test1.tsx
+++ b/src/pages/test1.tsx
@@ -34,16 +34,17 @@ export default function Test1() {
       console.error(error);
     }
   };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    setHtmlState(dataBaseItem?.htmlState);
-    setCssState(dataBaseItem?.cssState);
-  });
+    if (dataBaseItem) {
+      setHtmlState(dataBaseItem?.htmlState);
+      setCssState(dataBaseItem?.cssState);
+    }
+  }, [dataBaseItem]);
 
   return (
     <div>
       <Editor lang="html" initialString={htmlState} setState={updateState} />
-      <Editor lang="html" initialString={htmlState} setState={updateState} />
+      <Editor lang="css" initialString={cssState} setState={updateState} />
     </div>
   );
 }

--- a/src/pages/test1.tsx
+++ b/src/pages/test1.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '@model/db';
+import CodeMirror from '@uiw/react-codemirror';
+import { okaidia } from '@uiw/codemirror-theme-okaidia';
+import { html } from '@codemirror/lang-html';
+import { css } from '@codemirror/lang-css';
+
+const router = 'test1';
+export default function Test1() {
+  const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(router).toArray());
+  const [htmlState, setHtmlState] = useState('');
+  const [cssState, setCssState] = useState('');
+  useEffect(() => {
+    setHtmlState(dataBaseItem?.at(0)?.htmlState);
+    setCssState(dataBaseItem?.at(0)?.cssState);
+  }, [dataBaseItem]);
+
+  const updateHtmlState = async (view) => {
+    try {
+      await db.markups.put({ id: router, htmlState: view, cssState }, router);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const updateCssState = async (view) => {
+    try {
+      await db.markups.put({ id: router, htmlState, cssState: view }, router);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <div>
+      <CodeMirror value={htmlState} theme={okaidia} width="380px" height="380px" extensions={[html({ autoCloseTags: true })]} onChange={updateHtmlState} />
+      <CodeMirror value={cssState} theme={okaidia} width="380px" height="380px" extensions={[css()]} onChange={updateCssState} />
+    </div>
+  );
+}

--- a/src/pages/test1.tsx
+++ b/src/pages/test1.tsx
@@ -7,35 +7,47 @@ import { html } from '@codemirror/lang-html';
 import { css } from '@codemirror/lang-css';
 
 const router = 'test1';
+
 export default function Test1() {
-  const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(router).toArray());
+  const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(router).toArray())?.shift();
   const [htmlState, setHtmlState] = useState('');
   const [cssState, setCssState] = useState('');
+
+  const addState = async () => {
+    try {
+      await db.markups.add({ id: router, htmlState, cssState }, router);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const updateState = async (view, viewUpdate) => {
+    try {
+      const existedData = (await db.markups.where('id').equals(router).toArray()).length;
+      if (!existedData) addState();
+
+      const stateType = viewUpdate.view.contentAttrs['data-language'];
+
+      if (stateType === 'html') {
+        await db.markups.update(router, { htmlState: view });
+      } else if (stateType === 'css') {
+        await db.markups.update(router, { cssState: view });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
   useEffect(() => {
-    setHtmlState(dataBaseItem?.at(0)?.htmlState);
-    setCssState(dataBaseItem?.at(0)?.cssState);
+    if (dataBaseItem) {
+      setHtmlState(dataBaseItem?.htmlState);
+      setCssState(dataBaseItem?.cssState);
+    }
   }, [dataBaseItem]);
-
-  const updateHtmlState = async (view) => {
-    try {
-      await db.markups.put({ id: router, htmlState: view, cssState }, router);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  const updateCssState = async (view) => {
-    try {
-      await db.markups.put({ id: router, htmlState, cssState: view }, router);
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   return (
     <div>
-      <CodeMirror value={htmlState} theme={okaidia} width="380px" height="380px" extensions={[html({ autoCloseTags: true })]} onChange={updateHtmlState} />
-      <CodeMirror value={cssState} theme={okaidia} width="380px" height="380px" extensions={[css()]} onChange={updateCssState} />
+      <CodeMirror value={htmlState} theme={okaidia} width="380px" height="380px" extensions={[html({ autoCloseTags: true })]} onChange={updateState} />
+      <CodeMirror value={cssState} theme={okaidia} width="380px" height="380px" extensions={[css()]} onChange={updateState} />
     </div>
   );
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -18,7 +18,8 @@
       "@styles/*": ["styles/*"],
       "@quiz/*": ["quiz/*"],
       "@lib/*": ["lib/*"],
-      "@component/*": ["component/*"]
+      "@component/*": ["component/*"],
+      "@model/*": ["model/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## db.ts

```typescript
// 데이터베이스의 column값을 지정합니다.
export interface Markup {
  id: string;
  htmlState: string;
  cssState: string;
}

// 위의 columns 토대로 테이블을 생성하고, 기본키를 지정합니다.
export class MySubClassedDexie extends Dexie {
  markups!: Table<Markup>;

  constructor() {
    super('CamuDatabase');
    this.version(1).stores({
      markups: 'id', // primary key
    });
  }
}

export const db = new MySubClassedDexie();
```

## test1.tsx
- 파일 네이밍은 다이나믹 라우팅이 적용될 것으로 생각하여 만들었습니다.
- 데이터베이스 접근에 필요한 기본키값은 파일명을 따라가는 것으로 고려하여 작성했습니다.
- Dexie에서 제공하는 `useLiveQuery` 훅을 사용하여, 로컬스토리지의 데이터베이스에 접근합니다. (참고 : https://dexie.org/docs/dexie-react-hooks/useLiveQuery())
- 데이터베이스에 정보를 추가할 때, `put` 메소드를 사용했습니다. 파라미터로 넘긴 값이 데이터베이스에 없다면 추가(add)하고, 있다면 변경(update)합니다. `add`와 `update`를 나누지 않아도 될 것 같아 보입니다.

```tsx
// DB의 router 이름과 동일한 id를 찾아서 배열 형태로 반환
const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(router).toArray());

const [htmlState, setHtmlState] = useState('');
const [cssState, setCssState] = useState('');
useEffect(() => {
  setHtmlState(dataBaseItem?.at(0)?.htmlState);
  setCssState(dataBaseItem?.at(0)?.cssState);
}, [dataBaseItem]);

const updateHtmlState = async (view) => {
  try {
    await db.markups.put({ id: router, htmlState: view, cssState }, router);
  } catch (error) {
    console.error(error);
  }
};

const updateCssState = async (view) => {
  try {
    await db.markups.put({ id: router, htmlState, cssState: view }, router);
  } catch (error) {
    console.error(error);
  }
};
```

## 확인해보기
<img width="715" alt="image" src="https://github.com/Front-line-dev/markup-educator/assets/47382819/4c549717-0456-4617-9277-a8fcd6f94af3">

개발자도구 - 애플리케이션 - 저장용량 - IndexedDB에서 데이터베이스 진입할 수 있습니다.
코드에디터에 한글자씩 칠때마다 업데이트되므로, 네트워크 탭 하단에 있는 새로고침 아이콘을 누르면 갱신하여 확인할 수 있습니다.

