### PR TITLE
채점 기능 분리, 채점 애니메이션, 퀴즈 제작 페이지

### DIFF
--- a/src/component/Canvas.tsx
+++ b/src/component/Canvas.tsx
@@ -1,8 +1,5 @@
-import { MutableRefObject, forwardRef } from 'react';
 import styles from './Canvas.module.scss';
 
-function Canvas({ html, css }: { html: string; css: string }, ref: MutableRefObject<HTMLIFrameElement>) {
-  return <iframe srcDoc={`<style>${css}</style>${html}`} title="Rendered codes" className={styles.canvas} ref={ref} />;
+export default function Canvas({ html, css }: { html: string; css: string }) {
+  return <iframe srcDoc={`<style>${css}</style>${html}`} title="Rendered codes" className={styles.canvas} />;
 }
-
-export default forwardRef(Canvas);

--- a/src/component/quiz/QuizEditor.tsx
+++ b/src/component/quiz/QuizEditor.tsx
@@ -18,10 +18,9 @@ export default function QuizEditor({ wrapperClass, activate, html, css, handleAc
   const [htmlDebouncing, setHtmlDebouncing] = useState(false);
   const [cssDebouncing, setCssDebouncing] = useState(false);
 
-  // 린트 오류 더 살펴봐야 함 exhaustive-deps
   useEffect(() => {
     handleDebouncing(htmlDebouncing || cssDebouncing);
-  }, [htmlDebouncing, cssDebouncing]);
+  }, [htmlDebouncing, cssDebouncing, handleDebouncing]);
 
   return (
     <div className={classnames(styles.wrap, wrapperClass)}>

--- a/src/component/quiz/QuizResult.module.scss
+++ b/src/component/quiz/QuizResult.module.scss
@@ -12,6 +12,20 @@
   color: #fff;
 }
 
+.comparing {
+  &::before {
+    content: '채점중';
+  }
+
+  &::after {
+    content: '';
+    animation: comparing-animation 2s linear infinite;
+  }
+}
+
+.result {
+}
+
 .link {
   margin-top: 10px;
 }
@@ -26,5 +40,27 @@
 
   .link {
     margin-top: 40px;
+  }
+}
+
+@keyframes comparing-animation {
+  0% {
+    content: '.';
+  }
+
+  25% {
+    content: '..';
+  }
+
+  50% {
+    content: '...';
+  }
+
+  75% {
+    content: '';
+  }
+
+  100% {
+    content: '.';
   }
 }

--- a/src/component/quiz/QuizResult.tsx
+++ b/src/component/quiz/QuizResult.tsx
@@ -12,7 +12,9 @@ interface QuizResultProps {
 export default function QuizResult({ wrapperClassName, score, debouncing, comparing }: QuizResultProps) {
   return (
     <div className={classnames(styles.wrap, wrapperClassName)}>
-      <p className={styles.text}>{debouncing || comparing ? <span>채점중</span> : <span>유사도 {Math.floor(score * 100)}%</span>}</p>
+      <p className={styles.text}>
+        {debouncing || comparing ? <span className={styles.comparing} /> : <span className={styles.result}>유사도 {Math.floor(score * 100)}%</span>}
+      </p>
       {true && (
         <Link href="./" role="button" className={classnames(styles.link, 'contrast')}>
           다음 문제로

--- a/src/component/quiz/QuizResult.tsx
+++ b/src/component/quiz/QuizResult.tsx
@@ -6,12 +6,13 @@ interface QuizResultProps {
   wrapperClassName?: string;
   score: number;
   debouncing: boolean;
+  comparing: boolean;
 }
 
-export default function QuizResult({ wrapperClassName, score, debouncing }: QuizResultProps) {
+export default function QuizResult({ wrapperClassName, score, debouncing, comparing }: QuizResultProps) {
   return (
     <div className={classnames(styles.wrap, wrapperClassName)}>
-      <p className={styles.text}>{debouncing ? <span>채점중</span> : <span>유사도 {Math.floor(score * 100)}%</span>}</p>
+      <p className={styles.text}>{debouncing || comparing ? <span>채점중</span> : <span>유사도 {Math.floor(score * 100)}%</span>}</p>
       {true && (
         <Link href="./" role="button" className={classnames(styles.link, 'contrast')}>
           다음 문제로

--- a/src/component/quiz/QuizView.tsx
+++ b/src/component/quiz/QuizView.tsx
@@ -1,4 +1,3 @@
-import { MutableRefObject } from 'react';
 import classnames from 'classnames';
 import Canvas from '@component/Canvas';
 import styles from './QuizView.module.scss';
@@ -11,21 +10,9 @@ interface QuizViewProps {
   answerHtml: string;
   answerCss: string;
   handleActivate: (status: boolean) => void;
-  userCanvasRef: MutableRefObject<HTMLIFrameElement>;
-  answerCanvasRef: MutableRefObject<HTMLIFrameElement>;
 }
 
-export default function QuizView({
-  wrapperClass,
-  activate,
-  userHtml,
-  userCss,
-  answerHtml,
-  answerCss,
-  handleActivate,
-  userCanvasRef,
-  answerCanvasRef,
-}: QuizViewProps) {
+export default function QuizView({ wrapperClass, activate, userHtml, userCss, answerHtml, answerCss, handleActivate }: QuizViewProps) {
   return (
     <div className={classnames(styles.wrap, wrapperClass)}>
       <div className={styles.tab}>
@@ -52,13 +39,13 @@ export default function QuizView({
         <div className={classnames(styles.code, { [styles.activate]: activate })}>
           <span className={styles.code_label}>user</span>
           <div className={styles.canvas}>
-            <Canvas html={userHtml} css={userCss} ref={userCanvasRef} />
+            <Canvas html={userHtml} css={userCss} />
           </div>
         </div>
         <div className={classnames(styles.code, { [styles.activate]: !activate })}>
           <span className={styles.code_label}>answer</span>
           <div className={styles.canvas}>
-            <Canvas html={answerHtml} css={answerCss} ref={answerCanvasRef} />
+            <Canvas html={answerHtml} css={answerCss} />
           </div>
         </div>
       </div>

--- a/src/package.json
+++ b/src/package.json
@@ -30,6 +30,7 @@
     "npm": "^9.6.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-use-downloader": "^1.2.4",
     "sass": "^1.59.3",
     "typescript": "^4.9.5"
   },

--- a/src/pages/make.module.scss
+++ b/src/pages/make.module.scss
@@ -1,0 +1,29 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.editor_wrap {
+  display: flex;
+  gap: 50px;
+
+  & > * {
+    width: 500px;
+    height: 500px;
+  }
+}
+
+.canvas_wrap {
+  display: flex;
+  gap: 50px;
+
+  & > * {
+    width: 500px;
+    height: 500px;
+  }
+}
+
+.control_wrap {
+  width: 500px;
+}

--- a/src/pages/make.tsx
+++ b/src/pages/make.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import useDownloader from 'react-use-downloader';
+import Editor from '@component/Editor';
+import Canvas from '@component/Canvas';
+import styles from './make.module.scss';
+
+export default function Make() {
+  const { download } = useDownloader();
+  const [userHtml, setUserHtml] = useState('');
+  const [userCss, setUserCss] = useState('');
+  const [answerHtml, setAnswerHtml] = useState('');
+  const [answerCss, setAnswerCss] = useState('');
+  const [jsonName, setJsonName] = useState('');
+  const [jsonCategory, setJsonCategory] = useState('');
+  // Editor 호환용 변수
+  const [debouncing, setDebouncing] = useState(false);
+
+  function handleSave() {
+    const content = {
+      name: jsonName,
+      category: jsonCategory,
+      defaultUserHtml: userHtml,
+      defaultUserCss: userCss,
+      answerHtml,
+      answerCss,
+    };
+
+    // download json file
+    const fileURI = encodeURIComponent(JSON.stringify(content, null, 4));
+
+    console.log(fileURI);
+    download(`data:text/json,${fileURI}`, 'quiz.json');
+  }
+
+  return (
+    <div>
+      <main className={styles.main}>
+        <h2>USER</h2>
+        <div className={styles.editor_wrap}>
+          <Editor lang="html" initialString="" setString={setUserHtml} setDebouncing={setDebouncing} />
+          <Editor lang="css" initialString="" setString={setUserCss} setDebouncing={setDebouncing} />
+        </div>
+        <h2>ANSWER</h2>
+        <div className={styles.editor_wrap}>
+          <Editor lang="html" initialString="" setString={setAnswerHtml} setDebouncing={setDebouncing} />
+          <Editor lang="css" initialString="" setString={setAnswerCss} setDebouncing={setDebouncing} />
+        </div>
+        <div className={styles.canvas_wrap}>
+          <Canvas html={userHtml} css={userCss} />
+          <Canvas html={answerHtml} css={answerCss} />
+        </div>
+        <div className={styles.control_wrap}>
+          <label>
+            name: <input type="text" onChange={(e) => setJsonName(e.target.value)} />
+          </label>
+          <label>
+            category: <input type="text" onChange={(e) => setJsonCategory(e.target.value)} />
+          </label>
+          <button type="button" onClick={handleSave}>
+            save
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/quiz/[id].tsx
+++ b/src/pages/quiz/[id].tsx
@@ -12,15 +12,15 @@ import styles from './quiz.module.scss';
 interface QuizParams {
   id: string;
   name: string;
-  userHTML: string;
-  userCSS: string;
-  answerHTML: string;
-  answerCSS: string;
+  defaultUserHtml: string;
+  defaultUserCss: string;
+  answerHtml: string;
+  answerCss: string;
 }
 
-export default function Quiz({ id, name, userHTML, userCSS, answerHTML, answerCSS }: QuizParams) {
-  const [userHtmlString, setUserHtmlString] = useState(userHTML);
-  const [userCssString, setUserCssString] = useState(userCSS);
+export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answerHtml, answerCss }: QuizParams) {
+  const [userHtml, setUserHtml] = useState(defaultUserHtml);
+  const [userCss, setUserCss] = useState(defaultUserCss);
   const [activeHtmlStateTab, setActiveCodeTab] = useState(true);
   const [activeUserViewTab, setActiveUserViewTab] = useState(true);
   const [debouncing, setDebouncing] = useState(false);
@@ -30,38 +30,25 @@ export default function Quiz({ id, name, userHTML, userCSS, answerHTML, answerCS
   // db에서 코드 불러오기
   const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(id).toArray())?.shift();
   if (dataBaseItem) {
-    setUserHtmlString(dataBaseItem.htmlState);
-    setUserCssString(dataBaseItem.cssState);
+    setUserHtml(dataBaseItem.htmlState);
+    setUserCss(dataBaseItem.cssState);
   }
 
-  // 밑의 2개의 useEffect를 하나로 합치는게 알고리즘적으로는 더 이상적?
   useEffect(() => {
-    if (debouncing) {
-      console.log('DEBOUNCING: true');
-      // DEBOUNCING
-      // 채점중 문구 표시
-    } else {
-      console.log('DEBOUNCING: false');
-      // 채점 점수 보여줌
-    }
-  }, [debouncing]);
-
-  useEffect(() => {
-    console.log('HTML or CSS changed');
     // db에 코드 저장
     try {
-      db.markups.put({ id, htmlState: userHtmlString, cssState: userCssString }, id);
+      db.markups.put({ id, htmlState: userHtml, cssState: userCss }, id);
     } catch (error) {
       console.error(error);
     }
     // 채점
     async function handleCompare() {
       setComparing(true);
-      setScore(await compareMarkup(userHtmlString, userCssString, answerHTML, answerCSS));
+      setScore(await compareMarkup(userHtml, userCss, answerHtml, answerCss));
       setComparing(false);
     }
     handleCompare();
-  }, [userHtmlString, userCssString, answerHTML, answerCSS, id]);
+  }, [userHtml, userCss, answerHtml, answerCss, id]);
 
   return (
     <div className={styles.wrap}>
@@ -70,20 +57,20 @@ export default function Quiz({ id, name, userHTML, userCSS, answerHTML, answerCS
         <QuizEditor
           wrapperClass={styles.editor}
           activate={activeHtmlStateTab}
-          html={userHtmlString}
-          css={userCssString}
+          html={userHtml}
+          css={userCss}
           handleActivate={setActiveCodeTab}
-          handleHtml={setUserHtmlString}
-          handleCss={setUserCssString}
+          handleHtml={setUserHtml}
+          handleCss={setUserCss}
           handleDebouncing={setDebouncing}
         />
         <QuizView
           wrapperClass={styles.view}
           activate={activeUserViewTab}
-          userHtml={userHtmlString}
-          userCss={userCssString}
-          answerHtml={answerHTML}
-          answerCss={answerCSS}
+          userHtml={userHtml}
+          userCss={userCss}
+          answerHtml={answerHtml}
+          answerCss={answerCss}
           handleActivate={setActiveUserViewTab}
         />
         <QuizResult wrapperClassName={styles.grade} score={score} debouncing={debouncing} comparing={comparing} />
@@ -103,6 +90,6 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params }) {
   const quizFileData = readQuizFileById(params.id);
   return {
-    props: quizFileData,
+    props: { id: params.id, ...quizFileData },
   };
 }

--- a/src/quiz/1.json
+++ b/src/quiz/1.json
@@ -1,8 +1,7 @@
 {
-  "id": "1",
   "name": "환영 페이지",
-  "userHTML": "<h1>Hi</h1>",
-  "userCSS": "h1 { font-size: 2em; color: green; }",
-  "answerHTML": "<h1>Hi</h1>",
-  "answerCSS": "h1 { font-size: 2.5em; }"
+  "defaultUserHtml": "<h1>Hi</h1>",
+  "defaultUserCss": "h1 { font-size: 2em; color: green; }",
+  "answerHtml": "<h1>Hi</h1>",
+  "answerCss": "h1 { font-size: 2.5em; }"
 }

--- a/src/quiz/2.json
+++ b/src/quiz/2.json
@@ -1,8 +1,7 @@
 {
-  "id": "2",
   "name": "2 번째 페이지",
-  "userHTML": "<h1>Hiㅇㅇㅇㅇㅇㅇㅇ</h1>",
-  "userCSS": "h1 { font-size: 2em; color: blue; }",
-  "answerHTML": "<h1>Hiㅇㅇㅇㅇㅇ</h1>",
-  "answerCSS": "h1 { font-size: 2.5em; }"
+  "defaultUserHtml": "<h1>Hiㅇㅇㅇㅇㅇㅇㅇ</h1>",
+  "defaultUserCss": "h1 { font-size: 2em; color: blue; }",
+  "answerHtml": "<h1>Hiㅇㅇㅇㅇㅇ</h1>",
+  "answerCss": "h1 { font-size: 2.5em; }"
 }


### PR DESCRIPTION
채점 기능을 분리했습니다. 이제 채점은 html, css를 코드만 받아서 채점합니다. 채점 캔버스는 500x500으로 했습니다

채점시 약 50ms가 걸리는데 디바운싱까지 적용했으므로 크게 문제는 안 될 것 같습니다. 혹시 이래도 부족하다면 web workers를 적용해보겠습니다. 일단 해보려고 찾아봤는데 리액트 환경에서는 더 어려울 것 같습니다. 가능은 한 것 같습니다

채점 애니메이션은 CSS를 사용해서 만들었습니다

퀴즈 제작 페이지는 일단 `/make`로 만들었습니다. 보여주는 페이지가 아니기에 대충 기능만 작동하게 만들었습니다

- 그 외
  - 홈페이지에서 카테고리별 설정이 필요해서 퀴즈 데이터에 카테고리 추가
  - 변수명 통일
    - 뒤에 string을 붙이는게 낫다고 생각했는데 typescript 특성상 타입을 바로 알 수 있기 때문에 지웠습니다
    - userHTML -> userHtml 로 통일했습니다