### PR TITLE
퀴즈 페이지 수정 및 공통 컴포넌트화

### DIFF
--- a/src/component/Canvas.module.scss
+++ b/src/component/Canvas.module.scss
@@ -1,4 +1,6 @@
 .canvas {
   width: 100%;
   height: 100%;
+  border: 1px solid #424242;
+  border-radius: 0 4px 4px 4px;
 }

--- a/src/component/quiz/QuizEditor.module.scss
+++ b/src/component/quiz/QuizEditor.module.scss
@@ -3,11 +3,12 @@
   width: 107px;
   margin-bottom: 0;
   padding: 7px 0;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
+  border-radius: 4px 4px 0 0;
   box-shadow: none;
+  background-color: rgba(#19b3e6, 0.2);
   font-size: 14px;
   line-height: 17px;
+  color: #eee;
 
   & + .button_tab {
     margin-left: 1px;
@@ -15,6 +16,7 @@
 
   &.activate {
     background-color: #19b3e6;
+    color: #fff;
   }
 }
 

--- a/src/component/quiz/QuizEditor.module.scss
+++ b/src/component/quiz/QuizEditor.module.scss
@@ -1,25 +1,3 @@
-.button_tab {
-  position: relative;
-  width: 107px;
-  margin-bottom: 0;
-  padding: 7px 0;
-  border-radius: 4px 4px 0 0;
-  box-shadow: none;
-  background-color: rgba(#19b3e6, 0.2);
-  font-size: 14px;
-  line-height: 17px;
-  color: #eee;
-
-  & + .button_tab {
-    margin-left: 1px;
-  }
-
-  &.activate {
-    background-color: #19b3e6;
-    color: #fff;
-  }
-}
-
 .code {
   display: none;
 

--- a/src/component/quiz/QuizEditor.tsx
+++ b/src/component/quiz/QuizEditor.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import Editor from '@component/Editor';
+import QuizTabButton from '@component/quiz/QuizTabButton';
 import styles from './QuizEditor.module.scss';
 
 interface QuizEditorProps {
@@ -25,24 +26,8 @@ export default function QuizEditor({ wrapperClass, activate, html, css, handleAc
   return (
     <div className={classnames(styles.wrap, wrapperClass)}>
       <div className={styles.tab}>
-        <button
-          type="button"
-          className={classnames(styles.button_tab, {
-            [styles.activate]: activate,
-          })}
-          onClick={() => handleActivate(true)}
-        >
-          HTML
-        </button>
-        <button
-          type="button"
-          className={classnames(styles.button_tab, {
-            [styles.activate]: !activate,
-          })}
-          onClick={() => handleActivate(false)}
-        >
-          CSS
-        </button>
+        <QuizTabButton isActivate={activate} handleClick={handleActivate} activateTabType innerText="HTML" />
+        <QuizTabButton isActivate={!activate} handleClick={handleActivate} activateTabType={false} innerText="CSS" />
       </div>
       <div className={classnames(styles.code, { [styles.activate]: activate })}>
         <span className={styles.code_label}>html</span>

--- a/src/component/quiz/QuizTabButton.module.scss
+++ b/src/component/quiz/QuizTabButton.module.scss
@@ -1,0 +1,21 @@
+.wrap {
+  position: relative;
+  width: 107px;
+  margin-bottom: 0;
+  padding: 7px 0;
+  border-radius: 4px 4px 0 0;
+  box-shadow: none;
+  background-color: rgba(#19b3e6, 0.2);
+  font-size: 14px;
+  line-height: 17px;
+  color: #eee;
+
+  & + .wrap {
+    margin-left: 1px;
+  }
+
+  &.activate {
+    background-color: #19b3e6;
+    color: #fff;
+  }
+}

--- a/src/component/quiz/QuizTabButton.tsx
+++ b/src/component/quiz/QuizTabButton.tsx
@@ -1,0 +1,23 @@
+import classnames from 'classnames';
+import styles from './QuizTabButton.module.scss';
+
+interface QuizTabButtonProps {
+  isActivate: boolean;
+  handleClick: (status: boolean) => void;
+  activateTabType: boolean;
+  innerText: string;
+}
+
+export default function QuizTabButton({ isActivate, handleClick, activateTabType, innerText }: QuizTabButtonProps) {
+  return (
+    <button
+      type="button"
+      className={classnames(styles.wrap, {
+        [styles.activate]: isActivate,
+      })}
+      onClick={() => handleClick(activateTabType)}
+    >
+      {innerText}
+    </button>
+  );
+}

--- a/src/component/quiz/QuizView.module.scss
+++ b/src/component/quiz/QuizView.module.scss
@@ -1,25 +1,3 @@
-.button_tab {
-  position: relative;
-  width: 107px;
-  margin-bottom: 0;
-  padding: 7px 0;
-  border-radius: 4px 4px 0 0;
-  box-shadow: none;
-  background-color: rgba(#19b3e6, 0.2);
-  font-size: 14px;
-  line-height: 17px;
-  color: #eee;
-
-  & + .button_tab {
-    margin-left: 1px;
-  }
-
-  &.activate {
-    background-color: #19b3e6;
-    color: #fff;
-  }
-}
-
 .code {
   display: none;
 

--- a/src/component/quiz/QuizView.module.scss
+++ b/src/component/quiz/QuizView.module.scss
@@ -3,11 +3,12 @@
   width: 107px;
   margin-bottom: 0;
   padding: 7px 0;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
+  border-radius: 4px 4px 0 0;
   box-shadow: none;
+  background-color: rgba(#19b3e6, 0.2);
   font-size: 14px;
   line-height: 17px;
+  color: #eee;
 
   & + .button_tab {
     margin-left: 1px;
@@ -15,6 +16,7 @@
 
   &.activate {
     background-color: #19b3e6;
+    color: #fff;
   }
 }
 
@@ -43,6 +45,7 @@
 .canvas {
   width: 100%;
   aspect-ratio: 1 / 1;
+  background-color: #272822;
 }
 
 @include mediaQuery('tablet') {

--- a/src/component/quiz/QuizView.tsx
+++ b/src/component/quiz/QuizView.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import QuizTabButton from '@component/quiz/QuizTabButton';
 import Canvas from '@component/Canvas';
 import styles from './QuizView.module.scss';
 
@@ -16,24 +17,8 @@ export default function QuizView({ wrapperClass, activate, userHtml, userCss, an
   return (
     <div className={classnames(styles.wrap, wrapperClass)}>
       <div className={styles.tab}>
-        <button
-          type="button"
-          className={classnames(styles.button_tab, {
-            [styles.activate]: activate,
-          })}
-          onClick={() => handleActivate(true)}
-        >
-          user
-        </button>
-        <button
-          type="button"
-          className={classnames(styles.button_tab, {
-            [styles.activate]: !activate,
-          })}
-          onClick={() => handleActivate(false)}
-        >
-          answer
-        </button>
+        <QuizTabButton isActivate={activate} handleClick={handleActivate} activateTabType innerText="user" />
+        <QuizTabButton isActivate={!activate} handleClick={handleActivate} activateTabType={false} innerText="answer" />
       </div>
       <div className={styles.result}>
         <div className={classnames(styles.code, { [styles.activate]: activate })}>


### PR DESCRIPTION
- PicoCss 아웃에 따라 퀴즈 페이지를 마크업을 수정했습니다.
- 탭 버튼을 공통으로 분리하여 따로 컴포넌트를 만들었습니다.
- 에디터 부분과 결과 뷰어 창도 공통화가 가능한데요, https://github.com/Front-line-dev/markup-educator/pull/36 요 PR가 작업영역이 겹쳐져서 완료되면 추가 작업하겠습니다.