### PR TITLE
퀴즈 홈 마크업 수정

### DIFF
--- a/src/component/quiz/QuizEditor.module.scss
+++ b/src/component/quiz/QuizEditor.module.scss
@@ -21,6 +21,10 @@
     display: none;
   }
 
+  .editor {
+    display: flex;
+  }
+
   .code {
     display: block;
     flex: 1 0 0;

--- a/src/component/quiz/QuizEditor.module.scss
+++ b/src/component/quiz/QuizEditor.module.scss
@@ -26,8 +26,10 @@
   }
 
   .code {
-    display: block;
     flex: 1 0 0;
+    display: block;
+    width: 50%;
+
     & + & {
       margin-left: 20px;
     }

--- a/src/component/quiz/QuizEditor.tsx
+++ b/src/component/quiz/QuizEditor.tsx
@@ -12,7 +12,7 @@ interface QuizEditorProps {
   handleActivate: Dispatch<SetStateAction<boolean>>;
   handleHtml: Dispatch<SetStateAction<string>>;
   handleCss: Dispatch<SetStateAction<string>>;
-  handleDebouncing: Dispatch<SetStateAction<boolean>>;
+  handleDebouncing?: Dispatch<SetStateAction<boolean>>;
 }
 
 export default function QuizEditor({ wrapperClass, activate, html, css, handleActivate, handleHtml, handleCss, handleDebouncing }: QuizEditorProps) {
@@ -20,7 +20,9 @@ export default function QuizEditor({ wrapperClass, activate, html, css, handleAc
   const [cssDebouncing, setCssDebouncing] = useState(false);
 
   useEffect(() => {
-    handleDebouncing(htmlDebouncing || cssDebouncing);
+    if (handleDebouncing) {
+      handleDebouncing(htmlDebouncing || cssDebouncing);
+    }
   }, [htmlDebouncing, cssDebouncing, handleDebouncing]);
 
   return (

--- a/src/component/quiz/QuizEditor.tsx
+++ b/src/component/quiz/QuizEditor.tsx
@@ -26,21 +26,23 @@ export default function QuizEditor({ wrapperClass, activate, html, css, handleAc
   }, [htmlDebouncing, cssDebouncing, handleDebouncing]);
 
   return (
-    <div className={classnames(styles.wrap, wrapperClass)}>
+    <div className={classnames(wrapperClass)}>
       <div className={styles.tab}>
         <QuizTabButton isActivate={activate} handleClick={handleActivate} activateTabType innerText="HTML" />
         <QuizTabButton isActivate={!activate} handleClick={handleActivate} activateTabType={false} innerText="CSS" />
       </div>
-      <div className={classnames(styles.code, { [styles.activate]: activate })}>
-        <span className={styles.code_label}>html</span>
-        <div className={styles.code_inner}>
-          <Editor lang="html" initialString={html} setString={handleHtml} setDebouncing={setHtmlDebouncing} />
+      <div className={styles.editor}>
+        <div className={classnames(styles.code, { [styles.activate]: activate })}>
+          <span className={styles.code_label}>html</span>
+          <div className={styles.code_inner}>
+            <Editor lang="html" initialString={html} setString={handleHtml} setDebouncing={setHtmlDebouncing} />
+          </div>
         </div>
-      </div>
-      <div className={classnames(styles.code, { [styles.activate]: !activate })}>
-        <span className={styles.code_label}>css</span>
-        <div className={styles.code_inner}>
-          <Editor lang="css" initialString={css} setString={handleCss} setDebouncing={setCssDebouncing} />
+        <div className={classnames(styles.code, { [styles.activate]: !activate })}>
+          <span className={styles.code_label}>css</span>
+          <div className={styles.code_inner}>
+            <Editor lang="css" initialString={css} setString={handleCss} setDebouncing={setCssDebouncing} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/component/quiz/QuizResult.module.scss
+++ b/src/component/quiz/QuizResult.module.scss
@@ -23,9 +23,6 @@
   }
 }
 
-.result {
-}
-
 .link {
   margin-top: 10px;
   color: #fff;
@@ -35,6 +32,7 @@
   .wrap {
     justify-content: center;
   }
+
   .text {
     margin-top: 0;
   }

--- a/src/component/quiz/QuizView.module.scss
+++ b/src/component/quiz/QuizView.module.scss
@@ -16,10 +16,6 @@
   }
 }
 
-.result {
-  flex: 1 0 100%;
-}
-
 .canvas {
   width: 100%;
   aspect-ratio: 1 / 1;
@@ -29,7 +25,6 @@
 @include mediaQuery('tablet') {
   .result {
     display: flex;
-    justify-content: space-between;
   }
 
   .tab {

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -26,11 +26,19 @@
   text-align: center;
 }
 
-.quiz {
-  margin-top: 50px;
+.box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.box {
+.quiz {
+  margin-top: 50px;
+  width: 100%;
+}
+
+.start {
+  flex: 1 0 auto;
   margin-top: 30px;
   text-align: center;
 }
@@ -92,8 +100,12 @@
     max-width: 970px;
   }
 
-  .quiz {
-    flex-direction: row;
+  .link_start {
+    padding: 0 34px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 32px;
+    line-height: 98px;
   }
 }
 
@@ -101,5 +113,16 @@
   .main {
     flex-wrap: wrap;
     max-width: 1890px;
+  }
+
+  .box {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .quiz {
+    &:nth-child(2) {
+      width: 50%;
+    }
   }
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -27,8 +27,6 @@
 }
 
 .quiz {
-  display: flex;
-  flex-direction: column;
   margin-top: 50px;
 }
 
@@ -94,7 +92,7 @@
     max-width: 970px;
   }
 
-  .editor {
+  .quiz {
     flex-direction: row;
   }
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -4,9 +4,11 @@
   align-items: center;
   background-color: #202020;
 }
-
 .main {
+  width: 100%;
+  max-width: 500px;
   padding: 53px 25px 50px;
+  box-sizing: border-box;
 }
 
 .title {
@@ -24,47 +26,10 @@
   text-align: center;
 }
 
-.tab {
+.quiz {
   display: flex;
+  flex-direction: column;
   margin-top: 50px;
-}
-
-.button_tab {
-  position: relative;
-  width: 107px;
-  margin-bottom: 0;
-  padding: 7px 0;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-  box-shadow: none;
-  font-size: 14px;
-  line-height: 17px;
-
-  & + .button_tab {
-    margin-left: 1px;
-  }
-
-  &.activate {
-    background-color: #19b3e6;
-  }
-}
-
-.code {
-  overflow: hidden;
-  display: none;
-  border: 1px solid #424242;
-  border-radius: 0 4px 4px 4px;
-
-  &.activate {
-    display: block;
-  }
-}
-
-.result {
-  .code {
-    width: 380px;
-    height: 380px;
-  }
 }
 
 .box {
@@ -122,4 +87,21 @@
   font-size: 16px;
   line-height: 19px;
   list-style: none;
+}
+
+@include mediaQuery('tablet') {
+  .main {
+    max-width: 970px;
+  }
+
+  .editor {
+    flex-direction: row;
+  }
+}
+
+@include mediaQuery('pc_wide') {
+  .main {
+    flex-wrap: wrap;
+    max-width: 1890px;
+  }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,28 +19,30 @@ export default function Index() {
       <main className={styles.main}>
         <h1 className={styles.title}>Can yoU Mark Up ?</h1>
         <p className={styles.description}>화면을 똑같이 만들 수 있나요 ?</p>
-        <QuizEditor
-          wrapperClass={styles.quiz}
-          activate={activeHtmlStateTab}
-          html={htmlDefaultState}
-          css={cssDefaultState}
-          handleActivate={setActiveCodeTab}
-          handleHtml={setHtmlState}
-          handleCss={setCssState}
-        />
-        <QuizView
-          wrapperClass={styles.quiz}
-          activate={activeUserViewTab}
-          userHtml={htmlState}
-          userCss={cssState}
-          answerHtml=""
-          answerCss=""
-          handleActivate={setActiveUserViewTab}
-        />
         <div className={styles.box}>
-          <Link href="./quiz/1" className={classnames(styles.link_start, 'contrast')}>
-            시작하기
-          </Link>
+          <QuizEditor
+            wrapperClass={styles.quiz}
+            activate={activeHtmlStateTab}
+            html={htmlDefaultState}
+            css={cssDefaultState}
+            handleActivate={setActiveCodeTab}
+            handleHtml={setHtmlState}
+            handleCss={setCssState}
+          />
+          <QuizView
+            wrapperClass={styles.quiz}
+            activate={activeUserViewTab}
+            userHtml={htmlState}
+            userCss={cssState}
+            answerHtml=""
+            answerCss=""
+            handleActivate={setActiveUserViewTab}
+          />
+          <div className={styles.start}>
+            <Link href="./quiz/1" className={classnames(styles.link_start, 'contrast')}>
+              시작하기
+            </Link>
+          </div>
         </div>
         <h2 className={styles.quiz_title}>퀴즈 목록</h2>
         <div className={styles.quiz_box}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import classnames from 'classnames';
 import Link from 'next/link';
-import Canvas from '@component/Canvas';
-import Editor from '@component/Editor';
+import QuizEditor from '@component/quiz/QuizEditor';
+import QuizView from '@component/quiz/QuizView';
 import styles from './index.module.scss';
 
 const htmlDefaultState = `<div class="text">\n\tHello World\n</div>`;
@@ -19,60 +19,24 @@ export default function Index() {
       <main className={styles.main}>
         <h1 className={styles.title}>Can yoU Mark Up ?</h1>
         <p className={styles.description}>화면을 똑같이 만들 수 있나요 ?</p>
-        <div className={styles.tab}>
-          <button
-            type="button"
-            className={classnames(styles.button_tab, {
-              [styles.activate]: activeHtmlStateTab,
-            })}
-            onClick={() => setActiveCodeTab(true)}
-          >
-            html
-          </button>
-          <button
-            type="button"
-            className={classnames(styles.button_tab, {
-              [styles.activate]: !activeHtmlStateTab,
-            })}
-            onClick={() => setActiveCodeTab(false)}
-          >
-            css
-          </button>
-        </div>
-        <div className={classnames(styles.code, { [styles.activate]: activeHtmlStateTab })}>
-          <Editor lang="html" initialString={htmlDefaultState} setState={setHtmlState} />
-        </div>
-        <div className={classnames(styles.code, { [styles.activate]: !activeHtmlStateTab })}>
-          <Editor lang="css" initialString={cssDefaultState} setState={setCssState} />
-        </div>
-        <div className={styles.tab}>
-          <button
-            type="button"
-            className={classnames(styles.button_tab, {
-              [styles.activate]: activeUserViewTab,
-            })}
-            onClick={() => setActiveUserViewTab(true)}
-          >
-            user
-          </button>
-          <button
-            type="button"
-            className={classnames(styles.button_tab, {
-              [styles.activate]: !activeUserViewTab,
-            })}
-            onClick={() => setActiveUserViewTab(false)}
-          >
-            answer
-          </button>
-        </div>
-        <div className={styles.result}>
-          <div className={classnames(styles.code, { [styles.activate]: activeUserViewTab })}>
-            <Canvas html={htmlState} css={cssState} />
-          </div>
-          <div className={classnames(styles.code, { [styles.activate]: !activeUserViewTab })}>
-            <Canvas html="" css="" />
-          </div>
-        </div>
+        <QuizEditor
+          wrapperClass={styles.quiz}
+          activate={activeHtmlStateTab}
+          html={htmlDefaultState}
+          css={cssDefaultState}
+          handleActivate={setActiveCodeTab}
+          handleHtml={setHtmlState}
+          handleCss={setCssState}
+        />
+        <QuizView
+          wrapperClass={styles.quiz}
+          activate={activeUserViewTab}
+          userHtml={htmlState}
+          userCss={cssState}
+          answerHtml=""
+          answerCss=""
+          handleActivate={setActiveUserViewTab}
+        />
         <div className={styles.box}>
           <Link href="./quiz/1" className={classnames(styles.link_start, 'contrast')}>
             시작하기

--- a/src/pages/quiz/quiz.module.scss
+++ b/src/pages/quiz/quiz.module.scss
@@ -48,12 +48,6 @@
     max-width: 970px;
   }
 
-  .editor,
-  .view {
-    display: flex;
-    justify-content: space-between;
-  }
-
   .tab {
     display: none;
   }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -82,3 +82,7 @@ button {
 .modal_opened {
   overflow: hidden;
 }
+
+.cm-editor .cm-content {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
- 퀴즈 페이지와 비슷하게 마크업을 맞추었습니다. 
- @Front-line-dev 님, 퀴즈 홈에서는 디바운스가 필요없어서, 해당 props에 옵셔널체이닝을 추가했습니다. 또한, useEffect에서도 해당 값이 있을 때만 작동하도록 변경했습니다. 작업시 참고해주세요~