### PR TITLE
채점 기능 재작업

### DIFF
--- a/src/component/Canvas.tsx
+++ b/src/component/Canvas.tsx
@@ -3,7 +3,7 @@ import styles from './Canvas.module.scss';
 export default function Canvas({ html, css, type }: { html: string; css: string; type: string }) {
   return (
     <iframe
-      srcDoc={`<style>${css}</style>${html}<script>window.addEventListener('load', () => {window.top.postMessage('', '*');console.log('123')})</script>`}
+      srcDoc={`<style>${css}</style>${html}<script>window.addEventListener('load', () => {window.top.postMessage('', '*');})</script>`}
       title="Rendered codes"
       className={styles.canvas}
       data-type={type}

--- a/src/component/Canvas.tsx
+++ b/src/component/Canvas.tsx
@@ -1,5 +1,12 @@
 import styles from './Canvas.module.scss';
 
-export default function Canvas({ html, css }: { html: string; css: string }) {
-  return <iframe srcDoc={`<style>${css}</style>${html}`} title="Rendered codes" className={styles.canvas} />;
+export default function Canvas({ html, css, type }: { html: string; css: string; type: string }) {
+  return (
+    <iframe
+      srcDoc={`<style>${css}</style>${html}<script>window.addEventListener('load', () => {window.top.postMessage('', '*');console.log('123')})</script>`}
+      title="Rendered codes"
+      className={styles.canvas}
+      data-type={type}
+    />
+  );
 }

--- a/src/component/quiz/QuizView.tsx
+++ b/src/component/quiz/QuizView.tsx
@@ -11,9 +11,10 @@ interface QuizViewProps {
   answerHtml: string;
   answerCss: string;
   handleActivate: (status: boolean) => void;
+  iframeListenerReady: boolean;
 }
 
-export default function QuizView({ wrapperClass, activate, userHtml, userCss, answerHtml, answerCss, handleActivate }: QuizViewProps) {
+export default function QuizView({ wrapperClass, activate, userHtml, userCss, answerHtml, answerCss, handleActivate, iframeListenerReady }: QuizViewProps) {
   return (
     <div className={classnames(styles.wrap, wrapperClass)}>
       <div className={styles.tab}>
@@ -23,15 +24,11 @@ export default function QuizView({ wrapperClass, activate, userHtml, userCss, an
       <div className={styles.result}>
         <div className={classnames(styles.code, { [styles.activate]: activate })}>
           <span className={styles.code_label}>user</span>
-          <div className={styles.canvas}>
-            <Canvas html={userHtml} css={userCss} type="user" />
-          </div>
+          <div className={styles.canvas}>{iframeListenerReady && <Canvas html={userHtml} css={userCss} type="user" />}</div>
         </div>
         <div className={classnames(styles.code, { [styles.activate]: !activate })}>
           <span className={styles.code_label}>answer</span>
-          <div className={styles.canvas}>
-            <Canvas html={answerHtml} css={answerCss} type="answer" />
-          </div>
+          <div className={styles.canvas}>{iframeListenerReady && <Canvas html={answerHtml} css={answerCss} type="answer" />}</div>
         </div>
       </div>
     </div>

--- a/src/component/quiz/QuizView.tsx
+++ b/src/component/quiz/QuizView.tsx
@@ -24,13 +24,13 @@ export default function QuizView({ wrapperClass, activate, userHtml, userCss, an
         <div className={classnames(styles.code, { [styles.activate]: activate })}>
           <span className={styles.code_label}>user</span>
           <div className={styles.canvas}>
-            <Canvas html={userHtml} css={userCss} />
+            <Canvas html={userHtml} css={userCss} type="user" />
           </div>
         </div>
         <div className={classnames(styles.code, { [styles.activate]: !activate })}>
           <span className={styles.code_label}>answer</span>
           <div className={styles.canvas}>
-            <Canvas html={answerHtml} css={answerCss} />
+            <Canvas html={answerHtml} css={answerCss} type="answer" />
           </div>
         </div>
       </div>

--- a/src/pages/quiz/[id].tsx
+++ b/src/pages/quiz/[id].tsx
@@ -36,14 +36,18 @@ export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answer
   }
 
   useEffect(() => {
+    const iframeMap = { user: null, answer: null };
     // 아이프레임 이벤트 리스너 등록
-    function handleIframeMessage(event) {
+    async function handleIframeMessage(event) {
       if (event?.source?.location?.pathname === 'srcdoc') {
-        console.log(event);
-        console.log(event.source.frameElement.dataset.type);
-        // 이벤트가 발생될 때마다 해당되는 요소의 픽셀 데이터 업데이트
-        // 업데이트 후 스코어 다시 계산
-        // comparing = false
+        // 이벤트가 발생될 때마다 아이프레임 요소 업데이트
+        iframeMap[event.source.frameElement.dataset.type] = event.source;
+        // 요소에 접근해서 스코어 계산
+        if (iframeMap.user && iframeMap.answer) {
+          setComparing(true);
+          setScore(await compareMarkup(iframeMap.user, iframeMap.answer));
+          setComparing(false);
+        }
       }
     }
     window.addEventListener('message', handleIframeMessage);
@@ -64,13 +68,6 @@ export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answer
     } catch (error) {
       console.error(error);
     }
-    // 채점
-    // async function handleCompare() {
-    //   setComparing(true);
-    //   setScore(await compareMarkup(userHtml, userCss, answerHtml, answerCss));
-    //   setComparing(false);
-    // }
-    // handleCompare();
   }, [userHtml, userCss, id]);
 
   return (

--- a/src/pages/quiz/[id].tsx
+++ b/src/pages/quiz/[id].tsx
@@ -26,7 +26,7 @@ export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answer
   const [debouncing, setDebouncing] = useState(false);
   const [score, setScore] = useState(0);
   const [comparing, setComparing] = useState(false);
-  const [msgListenerReady, setMsgListenerReady] = useState(false);
+  const [iframeListenerReady, setIframeListenerReady] = useState(false);
 
   // db에서 코드 불러오기
   const dataBaseItem = useLiveQuery(() => db.markups.where('id').equals(id).toArray())?.shift();
@@ -53,7 +53,7 @@ export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answer
     window.addEventListener('message', handleIframeMessage);
 
     // 아이프레임 이벤트 발생을 위해 이벤트 리스너 등록 후 아이프레임 렌더
-    setMsgListenerReady(true);
+    setIframeListenerReady(true);
 
     return () => {
       // 아이프레임 이벤트 리스너 제거
@@ -84,17 +84,16 @@ export default function Quiz({ id, name, defaultUserHtml, defaultUserCss, answer
           handleCss={setUserCss}
           handleDebouncing={setDebouncing}
         />
-        {msgListenerReady && (
-          <QuizView
-            wrapperClass={styles.view}
-            activate={activeUserViewTab}
-            userHtml={userHtml}
-            userCss={userCss}
-            answerHtml={answerHtml}
-            answerCss={answerCss}
-            handleActivate={setActiveUserViewTab}
-          />
-        )}
+        <QuizView
+          wrapperClass={styles.view}
+          activate={activeUserViewTab}
+          userHtml={userHtml}
+          userCss={userCss}
+          answerHtml={answerHtml}
+          answerCss={answerCss}
+          handleActivate={setActiveUserViewTab}
+          iframeListenerReady={iframeListenerReady}
+        />
         <QuizResult wrapperClassName={styles.grade} score={score} debouncing={debouncing} comparing={comparing} />
       </main>
     </div>


### PR DESCRIPTION
채점 기능을 재작업했습니다

shadowDOM을 사용하면 shadowDOM 내부는 바깥하고 분리가 되는줄 알았는데 반대로 내부가 분리가 되는 것 같습니다. 따라서 shadowDOM 내부는 외부 스타일에 영향을 받습니다

결국에는 iframe을 캡쳐해서 채점을 해야하는 상황입니다

하지만 힘든 이유가 html, css가 바뀔 때 iframe을 캡쳐하면 아직 iframe이 렌더링 되지 않아서 빈 화면이 캡쳐됩니다. iframe 정보(위치)를 어떻게 넘겨주는가도 고민입니다

결국 중요한것은 iframe이 준비가 되었을 때 신호를 보내주는것인데 아이프레임 내에서 dom onload 이벤트 리스너 스크립트를 실행시켜서 postMessage로 top(parent)윈도우에 보낼 수 있습니다

postMessage를 받는 리스너는 window.addEventListener('message')로 useEffect를 사용해서 컴포넌트가 마운트 되었을 때 등록하고 없어질 때 return으로 해제하는 구조를 작성했습니다. 렌더링보다 useEffect가 발생시점이 늦어서 리스너 등록 후 렌더링 하도록 만든건 덤입니다

이렇게 했음에도 불구하고 라이브러리 문제인지 캡쳐를 하면 아래에 한 번 더 나타나는 버그가 있었습니다. 아이프레임을 캡쳐할 때 나타나는 버그 같습니다

결국 아이프레임을 캡쳐하기보다 아이프레임 내부의 DOM을 캡쳐하기로 하고 아이프레임 요소에서 width, height를 넘겨받아 캡쳐합니다

처음 시작했을 때 이 부분이 라이브러리가 있어서 구현이 쉽다고 생각했는데 가장 어려운 작업이 된 것 같습니다



덤: 현재 마스터 브랜치에서 데스크톱 화면에서 에디터를 사용하면 화면 크기가 계속 바뀌는 버그가 있는 것 같습니다