### PR TITLE
마크업 디자인 수정

### DIFF
--- a/src/component/header/header.module.scss
+++ b/src/component/header/header.module.scss
@@ -1,20 +1,27 @@
 .container {
-  display: flex;
-  align-items: center;
   width: 100%;
-  max-width: 970px;
   padding: 0 20px;
   box-sizing: border-box;
-  font-size: 18px;
   background-color: #19b3e6;
+}
+.inner {
+  display: flex;
+  align-items: center;
+  max-width: 970px;
+  margin: 0 auto;
   @include mediaQuery('pc_wide') {
-    max-width: 1600px;
+    max-width: 1500px;
   }
 }
 .title {
   font-size: 20px;
   line-height: 40px;
   color: #fff;
+
+  @include mediaQuery('pc_wide') {
+    font-size: 30px;
+    line-height: 60px;
+  }
 }
 .button_area {
   margin-left: auto;

--- a/src/component/header/index.tsx
+++ b/src/component/header/index.tsx
@@ -32,36 +32,38 @@ function Header({ quizList, resetHandler }: HeaderProps) {
 
   return (
     <header className={styles.container}>
-      <h1 className={styles.title}>
-        <a className={styles.home_link} href="#!">
-          Can you markup?
-        </a>
-      </h1>
-      <div className={styles.button_area}>
-        <button type="button" className={classnames(styles.top_button, styles.reset_button)} onClick={resetHandler}>
-          <span className="blind">코드 초기화</span>
-        </button>
-        <button type="button" className={classnames(styles.top_button, styles.share_button)} onClick={copyUrlButtonHandler}>
-          <span className="blind">공유</span>
-        </button>
-        <button type="button" onClick={toggleQuizListOpened} className={classnames(styles.top_button, styles.quiz_button)}>
-          <span className="blind">퀴즈목록</span>
-        </button>
-        {quizListOpened && (
-          <div className={styles.overlay}>
-            <div className={styles.dimmed} onClick={toggleQuizListOpened} aria-hidden="true" />
-            <div className={styles.quiz_list_area}>
-              <div className={styles.quiz_list_header}>
-                <strong className={styles.title}>퀴즈 리스트</strong>
-                <button type="button" className={styles.close_button} onClick={toggleQuizListOpened}>
-                  <span className="blind">닫기</span>
-                </button>
+      <div className={styles.inner}>
+        <h1 className={styles.title}>
+          <a className={styles.home_link} href="#!">
+            Can you markup?
+          </a>
+        </h1>
+        <div className={styles.button_area}>
+          <button type="button" className={classnames(styles.top_button, styles.reset_button)} onClick={resetHandler}>
+            <span className="blind">코드 초기화</span>
+          </button>
+          <button type="button" className={classnames(styles.top_button, styles.share_button)} onClick={copyUrlButtonHandler}>
+            <span className="blind">공유</span>
+          </button>
+          <button type="button" onClick={toggleQuizListOpened} className={classnames(styles.top_button, styles.quiz_button)}>
+            <span className="blind">퀴즈목록</span>
+          </button>
+          {quizListOpened && (
+            <div className={styles.overlay}>
+              <div className={styles.dimmed} onClick={toggleQuizListOpened} aria-hidden="true" />
+              <div className={styles.quiz_list_area}>
+                <div className={styles.quiz_list_header}>
+                  <strong className={styles.title}>퀴즈 리스트</strong>
+                  <button type="button" className={styles.close_button} onClick={toggleQuizListOpened}>
+                    <span className="blind">닫기</span>
+                  </button>
+                </div>
+                <QuizList quizList={quizList} />
               </div>
-              <QuizList quizList={quizList} />
             </div>
-          </div>
-        )}
-        {copySuccessPopupVisible && <p className={styles.copy_popup_text}>복사 되었습니다</p>}
+          )}
+          {copySuccessPopupVisible && <p className={styles.copy_popup_text}>복사 되었습니다</p>}
+        </div>
       </div>
     </header>
   );

--- a/src/component/header/index.tsx
+++ b/src/component/header/index.tsx
@@ -35,7 +35,7 @@ function Header({ quizList, resetHandler }: HeaderProps) {
     <header className={styles.container}>
       <div className={styles.inner}>
         <h1 className={styles.title}>
-          <a className={styles.home_link} href={isProduct ? '/markup-educator' : '\\'}>
+          <a className={styles.home_link} href={isProduct ? '/markup-educator' : '/'}>
             Can you markup?
           </a>
         </h1>

--- a/src/component/header/index.tsx
+++ b/src/component/header/index.tsx
@@ -34,7 +34,7 @@ function Header({ quizList, resetHandler }: HeaderProps) {
     <header className={styles.container}>
       <div className={styles.inner}>
         <h1 className={styles.title}>
-          <a className={styles.home_link} href="#!">
+          <a className={styles.home_link} href="\">
             Can you markup?
           </a>
         </h1>

--- a/src/component/header/index.tsx
+++ b/src/component/header/index.tsx
@@ -15,6 +15,7 @@ interface QuizParams {
 }
 
 function Header({ quizList, resetHandler }: HeaderProps) {
+  const isProduct = process.env.NODE_ENV === 'production';
   const [quizListOpened, setQuizListOpened] = useState(false);
   const [copySuccessPopupVisible, setCopySuccessPopupVisible] = useState(false);
 
@@ -34,7 +35,7 @@ function Header({ quizList, resetHandler }: HeaderProps) {
     <header className={styles.container}>
       <div className={styles.inner}>
         <h1 className={styles.title}>
-          <a className={styles.home_link} href="\">
+          <a className={styles.home_link} href={isProduct ? '/markup-educator' : '\\'}>
             Can you markup?
           </a>
         </h1>

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -62,8 +62,14 @@
   }
 }
 
+.quiz_section {
+  flex: 1 0 auto;
+  padding: 0 30px;
+}
+
 .quiz_title {
-  margin-top: 70px;
+  padding: 35px 0;
+  border-bottom: 1px solid #fff;
   font-size: 32px;
   line-height: 39px;
   color: #fff;
@@ -71,12 +77,11 @@
 }
 
 .quiz_box {
-  margin-top: 40px;
+  margin-top: 20px;
   color: #fff;
   text-align: center;
 
   & + .quiz_box {
-    margin-top: 20px;
     padding-top: 19px;
     border-top: 1px solid #fff;
   }
@@ -109,14 +114,6 @@
   .main {
     max-width: 970px;
   }
-
-  .link_start {
-    padding: 0 34px;
-    border-radius: 12px;
-    font-weight: bold;
-    font-size: 32px;
-    line-height: 98px;
-  }
 }
 
 @include mediaQuery('pc_wide') {
@@ -130,9 +127,30 @@
     flex-wrap: wrap;
   }
 
+  .link_start {
+    padding: 0 34px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 32px;
+    line-height: 98px;
+  }
+
   .quiz {
     &:nth-child(2) {
       width: 50%;
+    }
+  }
+
+  .quiz_area {
+    display: flex;
+  }
+
+  .quiz_box {
+    flex-basis: 33.33%;
+    padding: 0 10px;
+    & + .quiz_box {
+      padding-top: 0;
+      border: 0;
     }
   }
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-height: 100%;
   background-color: #202020;
 }
 .main {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import classnames from 'classnames';
 import { readQuizFiles } from '@lib/quiz/readFiles';
 import Link from 'next/link';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,8 +29,13 @@ export default function Index({ quizList }: QuizListProps) {
   return (
     <div className={styles.wrap}>
       <main className={styles.main}>
-        <h1 className={styles.title}>Can yoU Mark Up ?</h1>
-        <p className={styles.description}>화면을 똑같이 만들 수 있나요 ?</p>
+        <h1 className={styles.title}>Can yoU MarkUp ?</h1>
+        <p className={styles.description}>캔유마크업은 마크업 문제를 풀어보는 웹사이트입니다. html, css으로 동일한 화면을 만들어보아요.</p>
+        <div className={styles.start}>
+          <Link href="./quiz/1" className={classnames(styles.link_start, 'contrast')}>
+            시작하기
+          </Link>
+        </div>
         <div className={styles.box}>
           <QuizEditor
             wrapperClass={styles.quiz}
@@ -52,14 +57,11 @@ export default function Index({ quizList }: QuizListProps) {
             handleActivate={setActiveUserViewTab}
             iframeListenerReady
           />
-          <div className={styles.start}>
-            <Link href="./quiz/1" className={classnames(styles.link_start, 'contrast')}>
-              시작하기
-            </Link>
+          <div className={styles.quiz_section}>
+            <h2 className={styles.quiz_title}>퀴즈 목록</h2>
+            <QuizList quizList={quizList} />
           </div>
         </div>
-        <h2 className={styles.quiz_title}>퀴즈 목록</h2>
-        <QuizList quizList={quizList} />
       </main>
     </div>
   );

--- a/src/pages/quiz/[id].tsx
+++ b/src/pages/quiz/[id].tsx
@@ -113,7 +113,7 @@ export default function Quiz({ quizList, id, name, category, defaultUserHtml, de
       {clearAnimationState && <Confetti width={document.body.clientWidth - 50} height={document.body.clientHeight} recycle={false} />}
       <Header resetHandler={resetHandler} quizList={quizList} />
       <main className={styles.main}>
-        <div className={styles.name}>{name}</div>
+        <h2 className={styles.name}>{`# Quiz ${id} < ${name} >`}</h2>
         <QuizEditor
           wrapperClass={styles.editor}
           activate={activeHtmlStateTab}

--- a/src/pages/quiz/quiz.module.scss
+++ b/src/pages/quiz/quiz.module.scss
@@ -89,12 +89,14 @@
   }
 
   .grade {
-    flex-basis: 50%;
+    flex-basis: 0;
+    margin-left: 20px;
   }
 
   .view {
+    flex-basis: 0;
     order: 0;
-    max-width: 50%;
+    width: 50%;
     padding-top: 80px;
     box-sizing: border-box;
   }

--- a/src/pages/quiz/quiz.module.scss
+++ b/src/pages/quiz/quiz.module.scss
@@ -14,8 +14,9 @@
 }
 
 .name {
-  font-size: 20px;
-  line-height: 24px;
+  padding: 0 0 20px 5px;
+  font-size: 18px;
+  line-height: 22px;
   color: #fff;
 }
 
@@ -73,12 +74,18 @@
   }
 }
 
+@include mediaQuery('pc') {
+  .name {
+    font-size: 22px;
+    line-height: 26px;
+  }
+}
+
 @include mediaQuery('pc_wide') {
   .main {
     flex-wrap: wrap;
     max-width: none;
     width: 1500px;
-    padding-bottom: 0;
   }
 
   .grade {
@@ -87,7 +94,8 @@
 
   .view {
     order: 0;
-    flex-basis: 50%;
-    margin-top: 80px;
+    max-width: 50%;
+    padding-top: 80px;
+    box-sizing: border-box;
   }
 }


### PR DESCRIPTION
- 홈 영역
  - 시작하기 버튼을 상단으로 올렸습니다.
  - 1600px 이상에서 기존의 시작하기 버튼 영역에는 문제 리스트로 대체했습니다.
- 퀴즈 영역
  - 디바이스 크기가 넓을 때 헤더 영역의 좌우 여백을 늘려서 자연스럽게 노출했습니다.
  - 1600px 이상에서 뷰어 영역과 유사도 영역이 에디터 부분과 맞지 않아 어색한 부분을 수정했습니다.