### PR TITLE
정답률 잘못 계산되는 문제 수정

### DIFF
--- a/src/lib/score/compare.ts
+++ b/src/lib/score/compare.ts
@@ -1,4 +1,4 @@
-import { toPixelData } from 'html-to-image';
+import { toCanvas } from 'html-to-image';
 
 function calcSpectrum(userPixels, answerPixels) {
   const pixelLength = userPixels.length;
@@ -28,24 +28,19 @@ function calcPixelPerfect(userPixels, answerPixels) {
   return (identicalPixels / pixelLength) ** 5;
 }
 
-function getIframeSize(userIframe, answerIframe) {
-  const { width: userWidth, height: userHeight } = userIframe.frameElement.getBoundingClientRect();
-  const { width: answerWidth, height: answerHeight } = answerIframe.frameElement.getBoundingClientRect();
-
-  return {
-    width: Math.floor(Math.min(userWidth, answerWidth)),
-    height: Math.floor(Math.min(userHeight, answerHeight)),
-  };
+async function getPixels(el) {
+  const canvas = await toCanvas(el);
+  const pixels = canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height).data;
+  return pixels;
 }
 
 export default async function compareMarkup(userIframe, answerIframe) {
   console.time();
-  const sizeOption = getIframeSize(userIframe, answerIframe);
   let userPixels;
   let answerPixels;
   try {
-    userPixels = await toPixelData(userIframe.document.body, sizeOption);
-    answerPixels = await toPixelData(answerIframe.document.body, sizeOption);
+    userPixels = await getPixels(userIframe.document.body);
+    answerPixels = await getPixels(answerIframe.document.body);
   } catch (error) {
     console.error(error);
     return 0;


### PR DESCRIPTION
관련이슈: https://github.com/Front-line-dev/markup-educator/issues/74

@Front-line-dev 
코드를 확인해 보니 기존 소스가 비교 엘리먼트의 전체 영역을 캡쳐하지 않는 것 같습니다. 그래서 toCanvas()를 사용하여 의도한 영역을 캡쳐하도록 변경해 보았습니다. 아래는 기존 소스가 비교하는 이미지와 pr드리는 소스가 비교하는 이미지를 body에 붙여 본 것입니다.



### AS-IS
<img width="1090" alt="스크린샷 2023-12-20 오후 3 36 23" src="https://github.com/Front-line-dev/markup-educator/assets/2697040/835b30be-fc45-4f5d-98e4-2c7a977a3dea">


#### TO-BE
<img width="1116" alt="스크린샷 2023-12-20 오후 3 42 00" src="https://github.com/Front-line-dev/markup-educator/assets/2697040/ed367b1b-380f-4af3-a207-8e13bfa76251">


### User CSS 답변 샘플 
```css

.container {
  padding-bottom: 20px;
  text-align: center;
  background-color: white;
}
.button {
  width: 70px;
  height: 70px;
  margin-top: 20px;
  &:first-child {
    border: 3px green solid;
  }
  &:nth-child(2) {
    border: 3px green dashed;
  }
  &:nth-child(3) {
    border: 3px green dotted;
  }
  &:nth-child(4) {
    
  }
  &:nth-child(5) {
    border: 3px green;
    /* 50% */
  }
}
```
